### PR TITLE
Fix rwinlib for ucrt toolchains

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,0 +1,2 @@
+CRT=-ucrt
+include Makevars.win

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -5,17 +5,7 @@ TARGET = lib$(subst gcc,,$(COMPILED_BY))$(R_ARCH)
 
 PKG_LIBS = \
 	-L$(RWINLIB)/$(TARGET) \
-	-L$(RWINLIB)/lib$(R_ARCH) \
-	-lopencv_ml -lopencv_objdetect -lopencv_photo -lopencv_stitching \
-	-lopencv_video -lopencv_calib3d -lopencv_features2d -lopencv_highgui -lopencv_flann \
-	-lopencv_videoio -lopencv_imgcodecs -lopencv_imgproc -lopencv_core -ltbb \
-	-ljpeg -lwebp -lpng -lz -ltiff \
-	-lcomctl32 -lgdi32 -lole32 -lsetupapi -lws2_32 -lavifil32 -lavicap32 -lwinmm -lmsvfw32 \
-	-lopengl32 -lglu32 -lcomdlg32 -lOleAut32 -luuid
-
-PKG_LIBS = \
-	-L$(RWINLIB)/$(TARGET) \
-	-L$(RWINLIB)/lib$(R_ARCH) \
+	-L$(RWINLIB)/lib$(R_ARCH)$(CRT) \
 	-lopencv_highgui -lopencv_imgproc -lopencv_core -ltbb \
 	-ljpeg -lwebp -lpng -lz -ltiff \
 	-lcomctl32 -lgdi32 -lole32 -lsetupapi -lws2_32 -lavifil32 -lavicap32 -lwinmm -lmsvfw32 \


### PR DESCRIPTION
Small fix to make the rwinlib binaries compatible with ucrt, same as: https://github.com/ropensci/opencv/commit/16430f94d1fd8214edda62982e205d22039430b9

I also cleaned your Makevars.win a bit, because it was defining `PKG_LIBS` twice, where the second definition would override the first one. Not sure why it was there, perhaps some leftover from copying the setup from opencv?